### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return [
     'label' => 'Job Scheduler',
     'description' => 'TAO job scheduler',
     'license' => 'GPL-2.0',
-    'version' => '1.1.0',
+    'version' => '1.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis' => '>=6.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -23,7 +23,7 @@ return [
     'label' => 'Job Scheduler',
     'description' => 'TAO job scheduler',
     'license' => 'GPL-2.0',
-    'version' => '1.2.0',
+    'version' => '2.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis' => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -26,7 +26,7 @@ return [
     'version' => '1.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'generis' => '>=6.7.0',
+        'generis' => '>=12.5.0',
         'tao' => '>=15.10.0',
         'taoTaskQueue' => '>=1.2.0'
     ],

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -106,7 +106,7 @@ class Updater extends common_ext_ExtensionUpdater
             $migration->setServiceLocator($this->getServiceManager());
             $migration([]);
 
-            $this->setVersion('1.1.0');
+            $this->setVersion('1.2.0');
         }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -106,7 +106,7 @@ class Updater extends common_ext_ExtensionUpdater
             $migration->setServiceLocator($this->getServiceManager());
             $migration([]);
 
-            $this->setVersion('1.2.0');
+            $this->setVersion('2.0.0');
         }
     }
 }

--- a/test/model/action/ActionTest.php
+++ b/test/model/action/ActionTest.php
@@ -24,13 +24,14 @@ use oat\taoScheduler\model\action\Action;
 use oat\oatbox\extension\AbstractAction;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\action\Action as TaoAction;
+use oat\generis\test\TestCase;
 
 /**
  * Class ActionTest
  * @package oat\taoScheduler
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
  */
-class ActionTest extends \PHPUnit_Framework_TestCase
+class ActionTest extends TestCase
 {
 
     public function testInvoke()

--- a/test/model/job/JobTest.php
+++ b/test/model/job/JobTest.php
@@ -22,13 +22,14 @@ namespace oat\taoScheduler\test\model\job;
 
 use \DateTime;
 use oat\taoScheduler\model\job\Job;
+use oat\generis\test\TestCase;
 
 /**
  * Class JobTest
  * @package oat\taoScheduler
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
  */
-class JobTest extends \PHPUnit_Framework_TestCase
+class JobTest extends TestCase
 {
 
     public function testGetRRule()


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.
